### PR TITLE
fix : 메인페이지 예약현황이 공지사항 가림 수정, 예약현황 이동 모션 수정

### DIFF
--- a/src/components/Main/MainPage/MainPage.module.css
+++ b/src/components/Main/MainPage/MainPage.module.css
@@ -7,7 +7,7 @@
   /* font-family: Noto Sans KR, -apple-system, Roboto, Helvetica, sans-serif; */
   /* margin: 0 12px; */
   /* padding: 0 12px 0 0; */
-  height: 960px;
+  /* height: 960px; */
 }
 
 /* 앱바 ---------------------------------------------------------------------------  */
@@ -401,13 +401,17 @@
   font-weight: 700;
   padding: 6px 0 18px;
   z-index: 1000; /* 다른 요소들 위에 표시되도록 설정 */
-  transition: transform 3s ease-in-out; /* 스와이프 애니메이션 */
+  transition: transform 1s ease-in-out; /* 스와이프 애니메이션 */
   overflow-y: auto; /* 내부 콘텐츠가 스크롤 가능하도록 설정 */
-  height: 150px; /* 초기 높이 설정 */
+  height: 120px; /* 초기 높이 설정 */
 }
+.emptyBox {
+  height: 200px;
+}
+
 @media (min-height: 960px) {
   .recentBooking {
-    bottom: calc(100vh - 980px); /* 화면 높이에서 960px을 뺀 값으로 설정 */
+    bottom: calc(100vh - 1100px); /* 화면 높이에서 960px을 뺀 값으로 설정 */
   }
 }
 
@@ -436,21 +440,3 @@
 .recentBookingTitle {
   font-size: 20px;
 }
-
-/* @media (max-width: 640px) {
-  .recentBookingTitle {
-    margin-right: -5px;
-  }
-} */
-
-/* .recentBookingDetails {
-  font-size: 16px;
-  margin-top: 5px;
-  margin-right: 10px;
-} */
-
-/* @media (max-width: 640px) {
-  .recentBookingDetails {
-    margin-top: -1px;
-  }
-} */

--- a/src/components/Main/MainPage/MainPage.tsx
+++ b/src/components/Main/MainPage/MainPage.tsx
@@ -157,7 +157,7 @@ export const MainPage: React.FC = () => {
       setIsSwipedUp(true);
       setTimeout(() => {
         navigate("/Reservations");
-      }, 300); // 애니메이션 지속 시간과 동일하게 설정
+      }, 50); // 애니메이션 지속 시간과 동일하게 설정
     },
     preventScrollOnSwipe: true,
     trackMouse: true,
@@ -342,6 +342,11 @@ export const MainPage: React.FC = () => {
       <a href="/FAQ">
         <button className={styles.supportText}>문제가 있으신가요?</button>
       </a>
+
+
+      <div className={styles.emptyBox}>
+      {/* 여백을 가진 상자 */}
+      </div>
 
       {/* 최근 예약 섹션 */}
       <section


### PR DESCRIPTION

## #️⃣연관된 이슈

#123 

## 📝작업 내용

- 최근예약내역 크기만큼의 빈상자를 넣음
- 메인페이지 전체 화면 사이즈 고정 해제
- 최근 예약내역 애니메이션 속도 조절 (모션 자연스럽게)
    - swiper 변경 x  
  


### 스크린샷 
![스크린샷 2025-01-21 212955](https://github.com/user-attachments/assets/9670e476-0bcf-47e8-8d36-f1415fbb4e81)
![스크린샷 2025-01-21 212941](https://github.com/user-attachments/assets/2038a53a-4522-4dd2-8a4f-1e1252af6021)

