### PR TITLE
128 좌석선택 페이지 수정

### DIFF
--- a/src/components/Main/MainPage/MainPage.module.css
+++ b/src/components/Main/MainPage/MainPage.module.css
@@ -408,7 +408,7 @@
   z-index: 1000; /* 다른 요소들 위에 표시되도록 설정 */
   transition: transform 1s ease-in-out; /* 스와이프 애니메이션 */
   overflow-y: auto; /* 내부 콘텐츠가 스크롤 가능하도록 설정 */
-  height: 120px; /* 초기 높이 설정 */
+  height: 150px; /* 초기 높이 설정 */
 }
 .emptyBox {
   height: 200px;
@@ -444,4 +444,5 @@
 
 .recentBookingTitle {
   font-size: 20px;
+  overflow: hidden;
 }

--- a/src/components/Main/SeatMap/Seat.tsx
+++ b/src/components/Main/SeatMap/Seat.tsx
@@ -37,6 +37,7 @@ export const Seat: React.FC<SeatComponentProps> = ({ seatNumber, initialStatus, 
       <span className={styles.seatText}>
         {displayStatus === 'selected' ? '선택좌석' : seatNumber}
       </span>
+
     </button>
   );
 };

--- a/src/components/Main/SeatMap/SeatSelection.module.css
+++ b/src/components/Main/SeatMap/SeatSelection.module.css
@@ -254,19 +254,22 @@
   width: 17vw;
   max-width: 90px;
   aspect-ratio: 1 / 1; /* 1:1 비율 유지 */
+  position: relative;
 }
 .seatImg {
+  
   width: 15vw;
   max-width: 50px;
   aspect-ratio: 1 / 1; /* 1:1 비율 유지 */
 }
 .seatText {
+  position: absolute;
   font-size: 15px;
   line-height: 1;
   white-space: nowrap; /* 텍스트 줄바꿈 방지 */
-
-  /* width: 100%;  */
-  /* text-align: center;  */
+  top: 50%; /* 세로 가운데 정렬 */
+  left: 50%; /* 가로 가운데 정렬 */
+  transform: translate(-50%, -50%); /* 가운데 정렬을 위한 보정 */
 }
 
 /* ------------------------------------------------------------------------------------------------------- */

--- a/src/components/Main/SeatMap/SeatSelection.module.css
+++ b/src/components/Main/SeatMap/SeatSelection.module.css
@@ -215,12 +215,21 @@
   margin-top: 20px;
   position: relative;
 }
-
+.driverAndEntrance{
+  display: flex;
+  margin-top: 20px;
+}
 .driverLayout {
   display: flex;
   justify-content: center; /* 안쪽 요소를 가로 중앙에 정렬 */
   align-items: center; /* 안쪽 요소를 세로 중앙에 정렬 */
   width: 50%;
+}
+.driverText{
+  font-size: 15px;
+  font-weight: 700;
+  color: #6b6b6b;
+
 }
 
 .driverIcon {
@@ -265,11 +274,13 @@
 .seatText {
   position: absolute;
   font-size: 15px;
+  color: #414141;
   line-height: 1;
   white-space: nowrap; /* 텍스트 줄바꿈 방지 */
   top: 50%; /* 세로 가운데 정렬 */
   left: 50%; /* 가로 가운데 정렬 */
   transform: translate(-50%, -50%); /* 가운데 정렬을 위한 보정 */
+  margin: auto;
 }
 
 /* ------------------------------------------------------------------------------------------------------- */

--- a/src/components/Main/SeatMap/SeatSelection.tsx
+++ b/src/components/Main/SeatMap/SeatSelection.tsx
@@ -569,13 +569,15 @@ export const SeatSelection: React.FC = () => {
         <div className={styles.busLayout}>
           {" "}
           {/* 버스 레이아웃 */}
-          <div className={styles.driverLayout}>
-            <img
-              src="/img/seat/driver.png"
-              alt="Driver"
-              className={styles.driverIcon}
-            />{" "}
-            {/* 운전사 아이콘 */}
+          <div className={styles.driverAndEntrance}>
+            <div className={styles.driverLayout}>
+              <p className={styles.driverText}>
+                운전석
+              </p>
+            </div>
+            <div className={styles.driverLayout}>
+              <p className={styles.driverText}>출입구</p>
+            </div>
           </div>
           {/* <img src="/steering-wheel.svg" alt="Steering wheel" className={styles.steeringIcon} /> 운전대 아이콘 */}
           <div className={styles.seatGrid}>


### PR DESCRIPTION
## #️⃣연관된 이슈


#128 
## 📝작업 내용

- seatmap에 좌석번호를 좌석 아이콘안으로 이동 
- 운전석 아이콘을 텍스트로 변경, 출입구 텍스트 추가
- 메인페이지 최근예약현황 높이 변경, 예약현황 텍스트 스크롤 방지 

### 스크린샷 (선택)
![스크린샷 2025-01-21 233234](https://github.com/user-attachments/assets/b733a5f0-1994-4d9d-99f5-5a2b365ab09a)

## 💬리뷰 요구사항(선택)

seatmap 출입구 아이콘 어떻게 하실건지 의견 부탁드립니다 
