### PR TITLE
152 공지사항 깨짐 이슈

### DIFF
--- a/src/components/Main/MainPage/MainPage.module.css
+++ b/src/components/Main/MainPage/MainPage.module.css
@@ -328,31 +328,33 @@
   flex-direction: column;
   align-items: start;
   text-align: center;
-  padding: 23px 18px 8px;
-  margin: 0 2%;
+  /* padding: 23px 18px 8px; */
+  padding: 16px 10px 25px 10px;
+  margin: 2% 2%;
 }
 
 .noticeTitle {
   color: #000;
   font-size: 20px;
   font-weight: 600;
-  margin-left: 10px;
+  margin-left: 20px;
 }
 .noticeDivider {
-  width: 97%;
+  width: 100%;
   max-width: 100%;
   height: 1px;
   margin: auto 0;
   border: 1px solid rgba(0, 0, 0, 0.4);
-  margin: 0 auto;
+  /* margin: 0 auto; */
 }
 /* 공지사항 내용 */
 .noticeList {
   /* list-style-type: none; */
   padding: 0;
-  margin: 20px 0 13px 5px;
+  /* margin: 20px 0 13px 5px; */
   text-align: left;
-  margin: 20px;
+  /* margin: 20px; */
+  margin: 0 0 5px 25px;
 }
 
 .noticeList li {
@@ -365,9 +367,16 @@
 .noUnderline {
   text-decoration: none;
 }
+
+.noticeIconDiv{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+}
 /* ---------------------------------------------------------------------- */
 .noticeFooter {
-  align-self: end;
+  /* align-self: end; */
   display: flex;
   margin-top: 6px;
   width: 100%;
@@ -377,7 +386,8 @@
   color: rgba(0, 0, 0, 0.45);
   font-weight: 700;
   text-decoration-line: none;
-  justify-content: space-between;
+  /* justify-content: space-between; */
+  align-items: center;
 }
 
 .noticeIcon {
@@ -387,10 +397,12 @@
 }
 
 .noticeText {
-  flex-grow: 1; /* 텍스트 영역을 확장 */
-  text-align: center; /* 텍스트 가운데 정렬 */
-  object-position: center;
+  flex-grow: 1; 
+  text-align: center; 
+  /* object-position: center; */
   font-weight: 700;
+  line-height: 25px;
+  margin-left: 26px;
 }
 /* 문제가 있으신가요 ------------------------------------------- */
 .supportText {

--- a/src/components/Main/MainPage/MainPage.tsx
+++ b/src/components/Main/MainPage/MainPage.tsx
@@ -373,11 +373,13 @@ export const MainPage: React.FC = () => {
         <a className={styles.noticeFooter} href="/Notification">
           <div className={styles.noticeFooter}>
             <span className={styles.noticeText}>전체 공지사항 보기</span>
-            <img
-              src="/img/icon/reservelogo.svg"
-              alt=""
-              className={styles.noticeIcon}
-            />
+            <div className={styles.noticeIconDiv}>
+              <img
+                src="/img/icon/reservelogo.svg"
+                alt=""
+                className={styles.noticeIcon}
+              />
+            </div>
           </div>
         </a>
       </section>

--- a/src/components/Main/MainPage/MainPage.tsx
+++ b/src/components/Main/MainPage/MainPage.tsx
@@ -363,7 +363,7 @@ export const MainPage: React.FC = () => {
             target="_blank" // 새 탭에서 열기
             rel="noopener noreferrer" // 보안 설정
           >
-            <li>📢 [필독]통학버스 이용 에티켓 안내내</li>
+            <li>📢 [필독]통학버스 이용 에티켓 안내</li>
           </a>
         </ul>
 

--- a/src/components/Main/Notification/NotificationList.module.css
+++ b/src/components/Main/Notification/NotificationList.module.css
@@ -9,19 +9,24 @@
 }
 
 .header {
-  display: flex;
-  align-items: center;
-  margin-bottom: 20px;
-  margin:20px auto
+    background: #fff;
+    padding: 20px 16px;
+    display: flex;
+    align-items: center;
 }
 
 .icon {
   margin-right: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .title {
   font-size: 1.5rem;
   font-weight: bold;
+  width: 100%;
+  margin-right: 40px;
 }
 
 .error {
@@ -36,7 +41,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin:20px auto
+  margin: 20px auto;
 }
 
 .notificationBox {
@@ -46,7 +51,7 @@
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
   padding: 12px;
   transition: box-shadow 0.3s ease;
-  width:250px;
+  max-width: 358px;
   background-color:  #87ceeb;
 }
 
@@ -72,11 +77,26 @@
 }
 
 .description {
-  margin-top: 8px;
+  margin: 8px 0;
   font-size: 0.9rem;
   color: black;
   font-weight: 700;
+  word-break: keep-all;
+  word-spacing: normal;
 }
+
+.downloadButton {
+  display: block;
+  margin: 10px auto;
+  max-width: 120px;
+  padding: 8px 16px;
+  background-color: rgb(255, 255, 255);
+  color: #000;
+  border-radius: 4px;
+  text-decoration: none;
+  line-height: 20px;
+}
+
 
 .loading {
   text-align: center;

--- a/src/components/Main/Notification/NotificationList.tsx
+++ b/src/components/Main/Notification/NotificationList.tsx
@@ -65,6 +65,20 @@ const NotificationList = () => {
     );
   };
 
+  // description 내 URL을 링크로 변환하는 함수
+  const addDownloadLinkToDescription = (description: string) => {
+    const downloadText = "첨부파일 다운로드";
+    const regex = /첨부파일 다운로드/;
+
+    if (regex.test(description)) {
+      // description 내에 첨부파일 다운로드 텍스트가 있을 경우 링크 추가
+      const fileLink = "/path/to/file.pdf"; // 실제 파일 링크
+      return description.replace(regex, `<a href="${fileLink}" target="_blank" rel="noopener noreferrer" class="${styles.downloadButton}">${downloadText}</a>`);
+    }
+    
+    return description;
+  };
+
   return (
     <div className={styles.container}>
       {/* 헤더 */}
@@ -99,9 +113,10 @@ const NotificationList = () => {
               <div
                 className={styles.description}
                 style={{ display: notification.isExpanded ? 'block' : 'none' }}
-              >
-                {notification.description}
-              </div>
+                dangerouslySetInnerHTML={{
+                  __html: addDownloadLinkToDescription(notification.description)
+                }}
+              />
             </div>
           ))
         ) : (


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

메인페이지 공지사항 | 안내내 -> 안내 로 오타 수정
전체 공지사항 | 칸 깨짐 및 첨부파일 다운로드에 링크 걸리도록
(description안의 '첨부파일 다운로드'를 인식하여 링크)
![image](https://github.com/user-attachments/assets/2b88b0f7-b3e9-4cfc-9d63-b85a398bd64c)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 메인페이지 공지사항 | Public에 파일 넣으면 파일명대로 메인페이지에 고정되도록. 아직 미완성입니다.
