### PR TITLE
fix:  adjust header position on penalty details page

### DIFF
--- a/src/components/List/Penalty/RecentPenalties.module.css
+++ b/src/components/List/Penalty/RecentPenalties.module.css
@@ -1,3 +1,38 @@
+.container {
+  background-color: rgb(243, 244, 246);
+  display: flex;
+  padding-bottom: 385px;
+  flex-direction: column;
+  overflow: hidden;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+  max-height: 1000px;
+  font-family: Noto Sans KR, -apple-system, Roboto, Helvetica, sans-serif;
+}
+
+.header {
+  background-color: #fff;
+  align-self: stretch;
+  display: flex;
+  gap: 35px;
+  padding: 19px 23px;
+}
+
+.headerIcon {
+  width: 39px;
+}
+
+.headerTitle {
+  flex-grow: 0.45;
+  width: 50%;
+  font-size: 24px;
+  color: #000;
+  font-weight: 700;
+  text-align: center;
+  margin: 0;
+}
+/* ------------------ */
 .penaltyCount {
   font-size: 18px;
   font-weight: bold;

--- a/src/components/List/Penalty/RecentPenalties.tsx
+++ b/src/components/List/Penalty/RecentPenalties.tsx
@@ -94,8 +94,8 @@ const RecentPenalties: React.FC = () => {
   }, []);
 
   return (
-    <div className={styles.penaltyContainer}>
-      <header className={styles.penaltyHeader}>
+    <div className={styles.container}>
+      <header className={styles.header}>
         <a href="/Mypage" className={styles.headerIcon}>
           <img loading="lazy" src="img/icon/arrow-left.png" alt="뒤로가기" />
         </a>


### PR DESCRIPTION
## #️⃣연관된 이슈
#164 

## 📝작업 내용
패널티 내역 해더 부분 화살표 및 글자 위치 수정
- 해더 부분 css가 누락되어 있었음

### 스크린샷 (선택)

![스크린샷 2025-03-05 15-50-20](https://github.com/user-attachments/assets/dc00c5ba-b949-4159-8f2b-757d7ecfa6db)
