### PR TITLE
fix: Adjust header position and ratio on membership withdrawal page

### DIFF
--- a/src/components/Members/UserProfile/UserDelection.tsx
+++ b/src/components/Members/UserProfile/UserDelection.tsx
@@ -46,7 +46,7 @@ const UserDelection: React.FC = () => {
 
   return (
     <section className={styles.DelectionSection}>
-      <header className={styles.DelectionHeader}>
+      <header className={styles.header}>
         <button onClick={() => window.history.back()}>
           <img
             src="/img/icon/big-arrow-left.svg"

--- a/src/components/Members/UserProfile/UserProfile.module.css
+++ b/src/components/Members/UserProfile/UserProfile.module.css
@@ -159,18 +159,29 @@
     align-items: center;
     text-align: center;
   }
+
+  .header {
+    position: relative;
+    padding: 20px 21px;
+    display: flex;
+    align-items: center;
+    gap: 40px;
+    background-color: #fff;
+  }
   
   .headerIcon {
-    width: 39px;
+    align-items: center;
     aspect-ratio: 1.05;
-    object-fit: contain;
-    margin-top: 8px;
   }
   
   .headerTitle {
-    font: 700 24px 'Noto Sans KR', -apple-system, Roboto, Helvetica, sans-serif;
-    flex-grow: 1;
-    margin-right: 30px;
+    color: #000000;
+    font-family: "Noto Sans KR", sans-serif;
+    font-size: 24px;
+    font-weight: 700;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
   }
 
   .DelectionContent {


### PR DESCRIPTION
## #️⃣연관된 이슈
#166 


## 📝작업 내용

회원탈퇴 페이지 헤더 부분 위치 수정

### 스크린샷 (선택)
![스크린샷 2025-03-05 16-14-57](https://github.com/user-attachments/assets/49c5c693-2836-4e9f-a174-7c56f2f229a5)

